### PR TITLE
Add timeout for all request calls

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -7,6 +7,8 @@ JIRA_TICKET_URL_PREFIX = os.environ.get('JIRA_TICKET_URL_PREFIX')
 SLACK_HOOK_URL = os.environ['SLACK_HOOK_URL']
 COMMIT_REGEXP = os.environ['COMMIT_REGEXP']  # should fetch from repo settings
 
+REQUESTS_TIMEOUT = 10  # seconds
+
 PROJECTS_INFO: Final[List[Tuple[int, str, str, str]]] = [
     # (
     #   project_id,

--- a/src/pipelines.py
+++ b/src/pipelines.py
@@ -4,7 +4,7 @@ from typing import DefaultDict, List
 import requests
 from super_mario import BasePipeline, input_pipe, process_pipe, output_pipe
 
-from config import GITLAB_API_TOKEN
+from config import GITLAB_API_TOKEN, REQUESTS_TIMEOUT
 from utils.gitlab import (
     _is_commit_has_tests, get_ticket_id, is_revert_commit,
     get_message_for_commits, make_commit_message,
@@ -32,6 +32,7 @@ class AmyPipeline(BasePipeline):
                 'per_page': 100,
                 'with_stats': True,
             },
+            timeout=REQUESTS_TIMEOUT,
         ).json()
         return {'raw_commits': commits_list}
 

--- a/src/utils/gitlab.py
+++ b/src/utils/gitlab.py
@@ -11,7 +11,7 @@ import requests
 from config import (
     GITLAB_API_TOKEN, JIRA_TICKET_URL_PREFIX, DEVELEOPERS_INFO,
     GET_CORE_STAT_SHELL_COMMAND, REPO_TO_CODETYPE_MAPPING,
-    COMMIT_REGEXP)
+    COMMIT_REGEXP, REQUESTS_TIMEOUT)
 from utils.shell import run_shell_command
 from utils.format import bool_display
 
@@ -96,6 +96,7 @@ def fetch_diffs(project_id: int, commit_hash: str) -> List[CommitDiffInfo]:
     return requests.get(
         f'https://gitlab.com/api/v4//projects/{project_id}/repository/commits/{commit_hash}/diff',
         params={'private_token': GITLAB_API_TOKEN},
+        timeout=REQUESTS_TIMEOUT,
     ).json()
 
 
@@ -164,6 +165,7 @@ def get_commits_in_last_n_days(project_id: int, n_days: int) -> List[CommitInfo]
                 'page': page_num,  # type: ignore
                 'with_stats': True,
             },
+            timeout=REQUESTS_TIMEOUT,
         ).json()
         if not page_commits:
             break
@@ -179,4 +181,5 @@ def get_comments_for(commit_sha: str, project_id: int) -> List[Comment]:
             'private_token': GITLAB_API_TOKEN,
             'per_page': 100,  # type: ignore
         },
+        timeout=REQUESTS_TIMEOUT,
     ).json()

--- a/src/utils/slack.py
+++ b/src/utils/slack.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import requests
 
-from config import SLACK_HOOK_URL, DEBUG_SLACK_CHANNEL_ID, DEBUG
+from config import DEBUG, DEBUG_SLACK_CHANNEL_ID, REQUESTS_TIMEOUT, SLACK_HOOK_URL
 
 
 def send_slack_message(message: str, channel_id: str = None, **kwargs: Any) -> None:
@@ -11,4 +11,4 @@ def send_slack_message(message: str, channel_id: str = None, **kwargs: Any) -> N
         'channel': DEBUG_SLACK_CHANNEL_ID if DEBUG else channel_id,
         **kwargs,
     }
-    requests.post(SLACK_HOOK_URL, json=payload)
+    requests.post(SLACK_HOOK_URL, json=payload, timeout=REQUESTS_TIMEOUT)


### PR DESCRIPTION
Requests известен тем что умеет тупо зависать без явных признаков жизни (на что я и напоролся), так что лучше везде указывать задавать явно таймауты.